### PR TITLE
Fix category list in context menu

### DIFF
--- a/app/controllers/context_menus_controller.rb
+++ b/app/controllers/context_menus_controller.rb
@@ -39,6 +39,7 @@ class ContextMenusController < ApplicationController
     @assignables = @issues.map(&:assignable_users).reduce(:&)
     @trackers = @projects.map {|p| Issue.allowed_target_trackers(p) }.reduce(:&)
     @versions = @projects.map {|p| p.shared_versions.open}.reduce(:&)
+    @categories = @projects.map {|p| p.shared_categories}.reduce(:&)
 
     @priorities = IssuePriority.active.reverse
     @back = back_url

--- a/app/views/context_menus/issues.html.erb
+++ b/app/views/context_menus/issues.html.erb
@@ -77,11 +77,11 @@
   </li>
   <% end %>
 
-  <% if @safe_attributes.include?('category_id') && @project && @project.assignable_categories.any? -%>
+  <% if @safe_attributes.include?('category_id') && @project && @categories.any? -%>
   <li class="folder">
     <a href="#" class="submenu"><%= l(:field_category) %></a>
     <ul>
-    <% @project.assignable_categories.each do |u| -%>
+    <% @categories.each do |u| -%>
         <li><%= context_menu_link u.name, bulk_update_issues_path(:ids => @issue_ids, :issue => {'category_id' => u}, :back_url => @back), :method => :post,
                                   :selected => (@issue && u == @issue.category), :disabled => !@can[:edit] %></li>
     <% end -%>


### PR DESCRIPTION
Thank you for releasing this code.

I am checking the operation by merging this branch into redmine 's trunk.
I found a bug where I can not display context_menu on its way.
It seems to be caused by using Project#assignable_categories which does not exist.

I have not confirmed the details yet, but I think that the context menu will work by adding this change.
Could you confirm it?